### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 [Model Context Protocol](https://modelcontextprotocol.wiki) server for google search.
 A Playwright-based Model Context Protocol (MCP) tool that bypasses search engine anti-bot mechanisms, performs Google searches, and extracts results, providing real-time search capabilities for AI assistants like Claude and Cursor.
 
+<a href="https://glama.ai/mcp/servers/@modelcontextprotocol-servers/google-search-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@modelcontextprotocol-servers/google-search-mcp/badge" alt="Google Search MCP server" />
+</a>
+
 ## Features
 
 - **Anti-Bot Bypass**: Uses browser fingerprint spoofing and real user behavior simulation to avoid detection


### PR DESCRIPTION
This PR adds a badge for the [Google Search MCP](https://glama.ai/mcp/servers/@modelcontextprotocol-servers/google-search-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@modelcontextprotocol-servers/google-search-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@modelcontextprotocol-servers/google-search-mcp/badge" alt="Google Search MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.